### PR TITLE
Lock dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+aiohttp==3.8.4
+aiosignal==1.3.1
+async-timeout==4.0.2
+attrs==23.1.0
+charset-normalizer==3.1.0
+discord==2.2.2
+discord.py==2.2.2
+frozenlist==1.3.3
+idna==3.4
+multidict==6.0.4
+yarl==1.9.1


### PR DESCRIPTION
Installed the bot in a [virtual environment](https://docs.python.org/3/library/venv.html) and ran `pip freeze > requirements.txt`. Future contributors will be able to install dependencies using `pip install -r requirements.txt`